### PR TITLE
Update randomness generator with iterative method

### DIFF
--- a/lib/crypto/crypto-engine.js
+++ b/lib/crypto/crypto-engine.js
@@ -12,6 +12,10 @@ var nodeCrypto = global.process && global.process.versions && global.process.ver
 var EmptySha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
 var EmptySha512 = 'cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce' +
     '47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e';
+// maxRandomQuota is the max number of random bytes you can asks for from the cryptoEngine
+// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+var maxRandomQuota = 65536;
+
 
 /**
  * SHA-256 hash
@@ -148,15 +152,31 @@ function createAesCbc() {
 }
 
 /**
+ * Gets random bytes from the CryptoEngine
+ * @param {number} len - bytes count
+ * @return {Uint8Array} - random bytes
+ */
+function safeRandom(len) {
+    var randomBytes = new Uint8Array(len);
+    while (len > 0) {
+        var segmentSize = len % maxRandomQuota;
+        segmentSize = segmentSize > 0 ? segmentSize : maxRandomQuota;
+        var randomBytesSegment = new Uint8Array(segmentSize);
+        webCrypto.getRandomValues(randomBytesSegment);
+        len -= segmentSize;
+        randomBytes.set(randomBytesSegment, len);
+    }
+    return randomBytes;
+}
+
+/**
  * Generates random bytes of specified length
  * @param {Number} len
  * @returns {Uint8Array}
  */
 function random(len) {
     if (subtle) {
-        var cryptoBytes = new Uint8Array(len);
-        webCrypto.getRandomValues(cryptoBytes);
-        return cryptoBytes;
+        return safeRandom(len);
     } else if (nodeCrypto) {
         return new Uint8Array(nodeCrypto.randomBytes(len));
     } else {

--- a/lib/format/kdbx-header.js
+++ b/lib/format/kdbx-header.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/* Docs for the KDBX header schema:
+ * https://keepass.info/help/kb/kdbx_4.html#innerhdr
+ */
+
 var KdbxUuid = require('./kdbx-uuid'),
     Consts = require('./../defs/consts'),
     ProtectedValue = require('./../crypto/protected-value'),
@@ -226,7 +230,7 @@ KdbxHeader.prototype._readBinary = function(bytes, ctx) {
     var view = new DataView(bytes);
     var flags = view.getUint8(0);
     var isProtected = flags & HeaderConst.FlagBinaryProtected;
-    var binaryData = bytes.slice(1);
+    var binaryData = bytes.slice(1); // Actual data comes after the flag byte
 
     var binary = isProtected ? ProtectedValue.fromBinary(binaryData) : binaryData;
 
@@ -272,6 +276,7 @@ KdbxHeader.prototype._readField = function(stm, fields, ctx) {
     if (size > 0) {
         bytes = stm.readBytes(size);
     }
+    
     var headerField = fields[headerId];
     if (headerField) {
         var method = this['_read' + headerField.name];

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "kdbxweb",
-  "version": "1.1.0",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2805,7 +2805,7 @@
       "dev": true
     },
     "pako": {
-      "version": "git://github.com/keeweb/pako.git#653c0b00d8941c89d09ed4546d2179001ec44efc"
+      "version": "github:keeweb/pako#653c0b00d8941c89d09ed4546d2179001ec44efc"
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -3231,7 +3231,7 @@
       "dev": true
     },
     "text-encoding": {
-      "version": "git://github.com/keeweb/text-encoding.git#4dfb7cb0954c222852092f8b06ae4f6b4f60bfbb"
+      "version": "github:keeweb/text-encoding#4dfb7cb0954c222852092f8b06ae4f6b4f60bfbb"
     },
     "timers-browserify": {
       "version": "2.0.2",
@@ -3503,7 +3503,7 @@
       "dev": true
     },
     "xmldom": {
-      "version": "git://github.com/keeweb/xmldom.git#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
+      "version": "github:keeweb/xmldom#ec8f61f723e2f403adaf7a1bbf55ced4ff1ea0c6"
     },
     "xtend": {
       "version": "4.0.1",

--- a/test/crypto/crypto-engine.spec.js
+++ b/test/crypto/crypto-engine.spec.js
@@ -153,6 +153,12 @@ describe('CryptoEngine', function() {
             expect(rand3.length).to.be(10);
         });
 
+        it('can fill more than 65536 bytes', function() {
+            useDefaultImpl();
+            var rand1 = CryptoEngine.random(77111);
+            expect(rand1.length).to.be(77111);
+        });
+
         if (SubtleMockNode) {
             it('generates random bytes with subtle', function() {
                 useSubtleMock();


### PR DESCRIPTION

![screenshot_20180711_221425](https://user-images.githubusercontent.com/4214172/42670674-46e1d846-862a-11e8-8f13-14d53acd22fd.png)

In subdavis/Tusk#186 a user discovered behavior where attachments larger than 65536 bytes caused an error when using KDBXv4.  I confirmed the same behavior in KeeWeb.  This makes sense since protected attachments get a `salt` generated, and according to the SubtleCrypto docs, `getRandomBytes` cannot produce more than 65535 at a time.

This fixes that bug and adds a new test for it.