### PR TITLE
Replace insecure calls to buffer

### DIFF
--- a/lib/utils/byte-utils.js
+++ b/lib/utils/byte-utils.js
@@ -61,7 +61,7 @@ function stringToBytes(str) {
 function base64ToBytes(str) {
     if (typeof atob === 'undefined' && typeof Buffer === 'function') {
         // node.js doesn't have atob
-        var buffer = new Buffer(str, 'base64');
+        var buffer = Buffer.from(str, 'base64');
         return new Uint8Array(buffer);
     }
     var byteStr = atob(str);
@@ -83,7 +83,7 @@ function bytesToBase64(arr) {
     }
     if (typeof btoa === 'undefined' && typeof Buffer === 'function') {
         // node.js doesn't have btoa
-        var buffer = new Buffer(arr);
+        var buffer = Buffer.from(arr);
         return buffer.toString('base64');
     }
     var str = '';


### PR DESCRIPTION
In the byte-utils for node there are 2 insecure calls to `new Buffer()`.
This pull request replaces the with the recommended `Buffer.from()` calls.

Reference: https://nodejs.org/api/buffer.html#buffer_new_buffer_array