### PR TITLE
Document null arguments for KdbxCredentails

### DIFF
--- a/lib/format/kdbx-credentials.js
+++ b/lib/format/kdbx-credentials.js
@@ -10,8 +10,8 @@ var ProtectedValue = require('../crypto/protected-value'),
 
 /**
  * Credentials
- * @param {ProtectedValue} password
- * @param {String|ArrayBuffer|Uint8Array} [keyFile]
+ * @param {ProtectedValue|null} password
+ * @param {String|ArrayBuffer|Uint8Array|null} [keyFile]
  * @constructor
  */
 var KdbxCredentials = function (password, keyFile, challengeResponse) {
@@ -45,7 +45,7 @@ KdbxCredentials.prototype.setPassword = function (password) {
 
 /**
  * Set keyfile
- * @param {ArrayBuffer|Uint8Array} [keyFile]
+ * @param {ArrayBuffer|Uint8Array|null} [keyFile]
  */
 KdbxCredentials.prototype.setKeyFile = function (keyFile) {
     if (keyFile && !(keyFile instanceof ArrayBuffer) && !(keyFile instanceof Uint8Array)) {


### PR DESCRIPTION
Both `setPassword` and `setKeyFile` can accept null values for their arguments.

This behavior is used by keeweb to open files with a keyfile, but a null password: https://git.2li.ch/keeweb/keeweb/src/commit/fa4ff0b0c333a14467c039dbf98b948e90e8baf7/app/scripts/models/file-model.js#L82